### PR TITLE
Drop everything that isn't Java 8 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,3 @@
 language: java
 
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk6
-
-matrix:
-  allow_failures:
-    jdk:
-      - oraclejdk7
-      - openjdk6
+jdk: oraclejdk8


### PR DESCRIPTION
Seems like it doesn't compile with older versions of Java, which isn't a problem since we all _should_ be using Java 8.